### PR TITLE
Make has method a type guard

### DIFF
--- a/src/entrypoints/map-has.d.ts
+++ b/src/entrypoints/map-has.d.ts
@@ -1,9 +1,9 @@
 /// <reference path="utils.d.ts" />
 
 interface Map<K, V> {
-  has(value: K | (TSReset.WidenLiteral<K> & {})): boolean;
+  has(value: K | (TSReset.WidenLiteral<K> & {})): value is K;
 }
 
 interface ReadonlyMap<K, V> {
-  has(value: K | (TSReset.WidenLiteral<K> & {})): boolean;
+  has(value: K | (TSReset.WidenLiteral<K> & {})): value is K;
 }

--- a/src/entrypoints/set-has.d.ts
+++ b/src/entrypoints/set-has.d.ts
@@ -1,9 +1,9 @@
 /// <reference path="utils.d.ts" />
 
 interface Set<T> {
-  has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
+  has(value: T | (TSReset.WidenLiteral<T> & {})): value is T;
 }
 
 interface ReadonlySet<T> {
-  has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
+  has(value: T | (TSReset.WidenLiteral<T> & {})): value is T;
 }


### PR DESCRIPTION
While widening the `has` method helps, it still cause problems with cases where we want to access the data later:

```
if (map.has(key)) {
  map.get(key); // will fail since key was not narrowed
}
```