### PR TITLE
fix npm package is shipped with the `og-image.png` #211

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ tsconfig.json
 .changeset
 .turbo
 turbo.json
+og-image.png

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![TS Reset - Improved TypeScript's Built-in Typings](./og-image.png)
+![TS Reset - Improved TypeScript's Built-in Typings](https://raw.githubusercontent.com/mattpocock/ts-reset/main/og-image.png)
 
 **Without `ts-reset`**:
 


### PR DESCRIPTION
fix https://github.com/mattpocock/ts-reset/issues/211 by adding `og-image.png` in the `.npmignore` list