### PR TITLE
Add trim functionality with tests and update package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
       "types": "./dist/storage.d.ts",
       "import": "./dist/storage.mjs",
       "default": "./dist/storage.js"
+    },
+    "./trim": {
+      "types": "./dist/trim.d.ts",
+      "import": "./dist/trim.mjs",
+      "default": "./dist/trim.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -8,3 +8,4 @@
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
 /// <reference path="promise-catch.d.ts" />
+/// <reference path="trim.d.ts" />

--- a/src/entrypoints/trim.d.ts
+++ b/src/entrypoints/trim.d.ts
@@ -1,0 +1,17 @@
+type Whitespace = " " | "\n" | "\t";
+
+type TrimLeft<S extends string> = S extends `${Whitespace}${infer Rest}`
+  ? TrimLeft<Rest>
+  : S;
+
+type TrimRight<S extends string> = S extends `${infer Rest}${Whitespace}`
+  ? TrimRight<Rest>
+  : S;
+
+interface String {
+  trim<S extends string>(this: S): TrimLeft<TrimRight<S>>;
+  trimRight<S extends string>(this: S): TrimRight<S>;
+  trimStart<S extends string>(this: S): TrimLeft<S>;
+  trimLeft<S extends string>(this: S): TrimLeft<S>;
+  trimEnd<S extends string>(this: S): TrimRight<S>;
+}

--- a/src/tests/trim.ts
+++ b/src/tests/trim.ts
@@ -1,0 +1,70 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  const str = "  hello  " as const;
+
+  // trim tests
+  const trimmed = str.trim();
+  type trimTest = [Expect<Equal<typeof trimmed, "hello">>];
+
+  // trimStart/trimLeft tests
+  const trimmedStart = str.trimStart();
+  type trimStartTest = Expect<Equal<typeof trimmedStart, "hello  ">>;
+
+  const trimmedLeft = str.trimLeft();
+  type trimLeftTest = Expect<Equal<typeof trimmedLeft, "hello  ">>;
+
+  // trimEnd/trimRight tests
+  const trimmedEnd = str.trimEnd();
+  type trimEndTest = Expect<Equal<typeof trimmedEnd, "  hello">>;
+
+  const trimmedRight = str.trimRight();
+  type trimRightTest = Expect<Equal<typeof trimmedRight, "  hello">>;
+});
+
+doNotExecute(() => {
+  const str = "\thello\n" as const;
+
+  const trimmed = str.trim();
+  type trimTest = Expect<Equal<typeof trimmed, "hello">>;
+
+  const trimmedStart = str.trimStart();
+  type trimStartTest = Expect<Equal<typeof trimmedStart, "hello\n">>;
+
+  const trimmedEnd = str.trimEnd();
+  type trimEndTest = Expect<Equal<typeof trimmedEnd, "\thello">>;
+});
+
+doNotExecute(() => {
+  // Test with string literals that contain different whitespace combinations
+  const str = " \t\nhello world\t \n" as const;
+
+  const trimmed = str.trim();
+  type trimTest = Expect<Equal<typeof trimmed, "hello world">>;
+});
+
+doNotExecute(() => {
+  // Test with empty string and whitespace-only string
+  const emptyStr = "" as const;
+  const whitespaceStr = "   \t\n" as const;
+
+  const trimmedEmpty = emptyStr.trim();
+  type trimEmptyTest = Expect<Equal<typeof trimmedEmpty, "">>;
+
+  const trimmedWhitespace = whitespaceStr.trim();
+  type trimWhitespaceTest = Expect<Equal<typeof trimmedWhitespace, "">>;
+});
+
+doNotExecute(() => {
+  // Test with string type (not literals)
+  const str: string = "  hello  ";
+
+  const trimmed = str.trim();
+  type trimTest = Expect<Equal<typeof trimmed, string>>;
+
+  const trimmedStart = str.trimStart();
+  type trimStartTest = Expect<Equal<typeof trimmedStart, string>>;
+
+  const trimmedEnd = str.trimEnd();
+  type trimEndTest = Expect<Equal<typeof trimmedEnd, string>>;
+});


### PR DESCRIPTION
🧹 Fix: Improve typings for trim, trimStart, trimEnd, trimLeft, and trimRight on String
This PR enhances the type definitions for string trimming methods by introducing compile-time evaluation of the trimmed result. The updated types provide more precise behavior when working with string literals.

✅ Changes
Added a Whitespace type to define characters considered whitespace (" ", "\n", "\t").

Implemented TrimLeft and TrimRight recursive utility types to trim leading and trailing whitespace at the type level.

Updated the String interface to:

Type trim as TrimLeft<TrimRight<S>>

Type trimStart and trimLeft as TrimLeft<S>

Type trimEnd and trimRight as TrimRight<S>


❓ Why
This makes the trimming methods more type-safe and predictable when working with string literals, especially in utility-heavy codebases where precise typing can improve DX and static analysis.

Let me know if you'd like tests or further refinements — happy to collaborate!

