### PR TITLE
feat: add boolean-to-string entrypoint with custom toString method

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
       "import": "./dist/array-index-of.mjs",
       "default": "./dist/array-index-of.js"
     },
+    "./boolean-to-string": {
+      "types": "./dist/boolean-to-string.d.ts",
+      "import": "./dist/boolean-to-string.mjs",
+      "default": "./dist/boolean-to-string.js"
+    },
     "./dom": {
       "types": "./dist/dom.d.ts",
       "import": "./dist/dom.mjs",

--- a/src/entrypoints/boolean-to-string.d.ts
+++ b/src/entrypoints/boolean-to-string.d.ts
@@ -1,0 +1,3 @@
+interface Boolean {
+  toString(): `${boolean}`;
+}

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -9,3 +9,4 @@
 /// <reference path="array-index-of.d.ts" />
 /// <reference path="map-groupby.d.ts" />
 /// <reference path="object-groupby.d.ts" />
+/// <reference path="boolean-to-string.d.ts" />


### PR DESCRIPTION
`Boolean#toString()` returns `'true' | 'false'` instead of `string`