### PR TITLE
chore: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,18 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,17 +4,21 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/src/tests/boolean-constructor-negative-narrowing.ts
+++ b/src/tests/boolean-constructor-negative-narrowing.ts
@@ -19,9 +19,7 @@ interface BooleanConstructor {
   readonly prototype: Boolean;
 }
 
-type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
-  ? never
-  : T;
+type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n ? never : T;
 
 type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2

--- a/src/tests/clone-node.ts
+++ b/src/tests/clone-node.ts
@@ -10,7 +10,10 @@ doNotExecute(() => {
 
 // SVGElement.cloneNode(true) should return SVGElement (original issue #192)
 doNotExecute(() => {
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+  const svg = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "svg",
+  ) as SVGElement;
   const clone = svg.cloneNode(true);
 
   type test = Expect<Equal<typeof clone, SVGElement>>;

--- a/src/tests/filter-boolean-issue-233.ts
+++ b/src/tests/filter-boolean-issue-233.ts
@@ -20,10 +20,9 @@ doNotExecute(() => {
 
 // Case 2: filter(Boolean) assigned to variable - correctly errors
 doNotExecute(() => {
-  const badPets = [
-    { type: "cat", name: "Fluffy" },
-    { type: "dog" },
-  ].filter(Boolean);
+  const badPets = [{ type: "cat", name: "Fluffy" }, { type: "dog" }].filter(
+    Boolean,
+  );
 
   // @ts-expect-error - missing `name` on second element
   pet(badPets);
@@ -34,10 +33,7 @@ doNotExecute(() => {
 doNotExecute(() => {
   pet(
     // @ts-expect-error - missing `name` on second element
-    [
-      { type: "cat", name: "Fluffy" },
-      { type: "dog" },
-    ].filter(Boolean),
+    [{ type: "cat", name: "Fluffy" }, { type: "dog" }].filter(Boolean),
   );
 });
 

--- a/src/tests/object-groupby.ts
+++ b/src/tests/object-groupby.ts
@@ -22,9 +22,7 @@ doNotExecute(() => {
   );
 
   const group = grouped["first"];
-  type test = Expect<
-    Equal<typeof group, [string, ...string[]] | undefined>
-  >;
+  type test = Expect<Equal<typeof group, [string, ...string[]] | undefined>>;
 });
 
 // Assignability: grouped values should be assignable to T[]
@@ -43,7 +41,9 @@ doNotExecute(() => {
 
 // Destructuring after narrowing
 doNotExecute(() => {
-  const grouped = Object.groupBy([1, 2, 3], (x) => (x % 2 === 0 ? "even" : "odd"));
+  const grouped = Object.groupBy([1, 2, 3], (x) =>
+    x % 2 === 0 ? "even" : "odd",
+  );
 
   const group = grouped["even"];
   if (group) {
@@ -78,7 +78,9 @@ doNotExecute(() => {
   type test = Expect<
     Equal<
       typeof grouped,
-      Partial<Record<Role, [(typeof items)[number], ...(typeof items)[number][]]>>
+      Partial<
+        Record<Role, [(typeof items)[number], ...(typeof items)[number][]]>
+      >
     >
   >;
 });


### PR DESCRIPTION
## Summary

- update GitHub Actions workflows from Node 20-based action versions to Node 24-compatible versions
- run CI and publish jobs on Node 24
- add explicit least-privilege workflow permissions
- format existing test files that failed the repository's current `format:check` CI step

## Details

This updates:

- `actions/checkout@v4` → `actions/checkout@v7`
- `pnpm/action-setup@v4` → `pnpm/action-setup@v6`
- `actions/setup-node@v4` → `actions/setup-node@v6`
- `node-version: 20.x` → `node-version: 24.x`

It also adds explicit workflow token permissions:

- CI: `contents: read`
- Publish: `contents: write`, `pull-requests: write`

## Validation

- Parsed both workflow YAML files locally
- Ran `git diff --check`
- Checked there are no remaining Node 20 / old v4 action references in `.github/workflows`
- Ran `pnpm run ci` locally

I intentionally did not add a publish environment gate here, to avoid changing the current release approval flow.
